### PR TITLE
Fix message in panic when not type not interface

### DIFF
--- a/mocktail.go
+++ b/mocktail.go
@@ -148,7 +148,10 @@ func walk(root, moduleName string) (map[string]PackageDesc, error) {
 
 			interfaceDesc := InterfaceDesc{Name: interfaceName}
 
-			interfaceType := lookup.Type().Underlying().(*types.Interface)
+			interfaceType, ok := lookup.Type().Underlying().(*types.Interface)
+			if !ok {
+				panic(fmt.Errorf("type %q in %q is not an interface", lookup.Type(), fp))
+			}
 
 			for i := 0; i < interfaceType.NumMethods(); i++ {
 				method := interfaceType.Method(i)

--- a/testdata/panicmsg/a/a.go
+++ b/testdata/panicmsg/a/a.go
@@ -1,0 +1,3 @@
+package a
+
+type A struct{}

--- a/testdata/panicmsg/a/go.mod
+++ b/testdata/panicmsg/a/go.mod
@@ -1,0 +1,3 @@
+module a
+
+go 1.18

--- a/testdata/panicmsg/a/mock_test.go
+++ b/testdata/panicmsg/a/mock_test.go
@@ -1,0 +1,3 @@
+package a
+
+// mocktail:A


### PR DESCRIPTION
If a type is not an interface then mocktail will panic with the following message:

```
panic: interface conversion: types.Type is *types.Struct, not *types.Interface
```

If you have many `mock_test.go` files with a lot of mocktail magic comments it gets very hard to find which of the types were not an interface.

This fix changes the message of the panic to the following:

```
panic: type "a.A" in "/Projekte/traefik/mocktail/testdata/panicmsg/a/mock_test.go" is not an interface
```