### PR TITLE
Fix versionned packages

### DIFF
--- a/syrup.go
+++ b/syrup.go
@@ -610,20 +610,19 @@ func (s Syrup) getTupleTypes(t *types.Tuple) []string {
 }
 
 func (s Syrup) getNamedTypeName(t *types.Named) string {
+	if t.Obj() != nil && t.Obj().Pkg() != nil {
+		if t.Obj().Pkg().Path() == s.PkgPath {
+			return t.Obj().Name()
+		}
+		return t.Obj().Pkg().Name() + "." + t.Obj().Name()
+	}
+
 	name := t.String()
 
 	i := strings.LastIndex(t.String(), "/")
 	if i > -1 {
 		name = name[i+1:]
 	}
-
-	if t.Obj() != nil && t.Obj().Pkg() != nil {
-		if t.Obj().Pkg().Path() == s.PkgPath {
-			i := strings.Index(name, ".")
-			return name[i+1:]
-		}
-	}
-
 	return name
 }
 

--- a/testdata/src/a/d/d.go
+++ b/testdata/src/a/d/d.go
@@ -1,0 +1,9 @@
+package c
+
+import (
+	"a/e/v2"
+)
+
+type Cherry interface {
+	V2Carrot() e.V2Carrot
+}

--- a/testdata/src/a/e/v2/e.go
+++ b/testdata/src/a/e/v2/e.go
@@ -1,0 +1,14 @@
+package e
+
+import (
+	"a/c"
+)
+
+type V2Carrot interface {
+	Bar(string) *V2Potato
+	Bur(string) *c.Cherry
+}
+
+type V2Potato struct {
+	Name string
+}

--- a/testdata/src/a/mock_gen_test.go
+++ b/testdata/src/a/mock_gen_test.go
@@ -5,6 +5,7 @@ package a
 import (
 	"a/b"
 	"a/c"
+	"a/e/v2"
 	"bytes"
 	"context"
 	"testing"
@@ -3394,4 +3395,109 @@ func (_c *orangeJuiceCall) OnJuice() *orangeJuiceCall {
 
 func (_c *orangeJuiceCall) OnJuiceRaw() *orangeJuiceCall {
 	return _c.Parent.OnJuiceRaw()
+}
+
+// cherryMock mock of Cherry.
+type cherryMock struct{ mock.Mock }
+
+// newCherryMock creates a new cherryMock.
+func newCherryMock(tb testing.TB) *cherryMock {
+	tb.Helper()
+
+	m := &cherryMock{}
+	m.Mock.Test(tb)
+
+	tb.Cleanup(func() { m.AssertExpectations(tb) })
+
+	return m
+}
+
+func (_m *cherryMock) V2Carrot() e.V2Carrot {
+	_ret := _m.Called()
+
+	if _rf, ok := _ret.Get(0).(func() e.V2Carrot); ok {
+		return _rf()
+	}
+
+	_ra0, _ := _ret.Get(0).(e.V2Carrot)
+
+	return _ra0
+}
+
+func (_m *cherryMock) OnV2Carrot() *cherryV2CarrotCall {
+	return &cherryV2CarrotCall{Call: _m.Mock.On("V2Carrot"), Parent: _m}
+}
+
+func (_m *cherryMock) OnV2CarrotRaw() *cherryV2CarrotCall {
+	return &cherryV2CarrotCall{Call: _m.Mock.On("V2Carrot"), Parent: _m}
+}
+
+type cherryV2CarrotCall struct {
+	*mock.Call
+	Parent *cherryMock
+}
+
+func (_c *cherryV2CarrotCall) Panic(msg string) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Panic(msg)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Once() *cherryV2CarrotCall {
+	_c.Call = _c.Call.Once()
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Twice() *cherryV2CarrotCall {
+	_c.Call = _c.Call.Twice()
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Times(i int) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Times(i)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) WaitUntil(w <-chan time.Time) *cherryV2CarrotCall {
+	_c.Call = _c.Call.WaitUntil(w)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) After(d time.Duration) *cherryV2CarrotCall {
+	_c.Call = _c.Call.After(d)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Run(fn func(args mock.Arguments)) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Run(fn)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Maybe() *cherryV2CarrotCall {
+	_c.Call = _c.Call.Maybe()
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) TypedReturns(a e.V2Carrot) *cherryV2CarrotCall {
+	_c.Call = _c.Return(a)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) ReturnsFn(fn func() e.V2Carrot) *cherryV2CarrotCall {
+	_c.Call = _c.Return(fn)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) TypedRun(fn func()) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Run(func(args mock.Arguments) {
+		fn()
+	})
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) OnV2Carrot() *cherryV2CarrotCall {
+	return _c.Parent.OnV2Carrot()
+}
+
+func (_c *cherryV2CarrotCall) OnV2CarrotRaw() *cherryV2CarrotCall {
+	return _c.Parent.OnV2CarrotRaw()
 }

--- a/testdata/src/a/mock_gen_test.go.golden
+++ b/testdata/src/a/mock_gen_test.go.golden
@@ -5,6 +5,7 @@ package a
 import (
 	"a/b"
 	"a/c"
+	"a/e/v2"
 	"bytes"
 	"context"
 	"testing"
@@ -3394,4 +3395,109 @@ func (_c *orangeJuiceCall) OnJuice() *orangeJuiceCall {
 
 func (_c *orangeJuiceCall) OnJuiceRaw() *orangeJuiceCall {
 	return _c.Parent.OnJuiceRaw()
+}
+
+// cherryMock mock of Cherry.
+type cherryMock struct{ mock.Mock }
+
+// newCherryMock creates a new cherryMock.
+func newCherryMock(tb testing.TB) *cherryMock {
+	tb.Helper()
+
+	m := &cherryMock{}
+	m.Mock.Test(tb)
+
+	tb.Cleanup(func() { m.AssertExpectations(tb) })
+
+	return m
+}
+
+func (_m *cherryMock) V2Carrot() e.V2Carrot {
+	_ret := _m.Called()
+
+	if _rf, ok := _ret.Get(0).(func() e.V2Carrot); ok {
+		return _rf()
+	}
+
+	_ra0, _ := _ret.Get(0).(e.V2Carrot)
+
+	return _ra0
+}
+
+func (_m *cherryMock) OnV2Carrot() *cherryV2CarrotCall {
+	return &cherryV2CarrotCall{Call: _m.Mock.On("V2Carrot"), Parent: _m}
+}
+
+func (_m *cherryMock) OnV2CarrotRaw() *cherryV2CarrotCall {
+	return &cherryV2CarrotCall{Call: _m.Mock.On("V2Carrot"), Parent: _m}
+}
+
+type cherryV2CarrotCall struct {
+	*mock.Call
+	Parent *cherryMock
+}
+
+func (_c *cherryV2CarrotCall) Panic(msg string) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Panic(msg)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Once() *cherryV2CarrotCall {
+	_c.Call = _c.Call.Once()
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Twice() *cherryV2CarrotCall {
+	_c.Call = _c.Call.Twice()
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Times(i int) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Times(i)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) WaitUntil(w <-chan time.Time) *cherryV2CarrotCall {
+	_c.Call = _c.Call.WaitUntil(w)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) After(d time.Duration) *cherryV2CarrotCall {
+	_c.Call = _c.Call.After(d)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Run(fn func(args mock.Arguments)) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Run(fn)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) Maybe() *cherryV2CarrotCall {
+	_c.Call = _c.Call.Maybe()
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) TypedReturns(a e.V2Carrot) *cherryV2CarrotCall {
+	_c.Call = _c.Return(a)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) ReturnsFn(fn func() e.V2Carrot) *cherryV2CarrotCall {
+	_c.Call = _c.Return(fn)
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) TypedRun(fn func()) *cherryV2CarrotCall {
+	_c.Call = _c.Call.Run(func(args mock.Arguments) {
+		fn()
+	})
+	return _c
+}
+
+func (_c *cherryV2CarrotCall) OnV2Carrot() *cherryV2CarrotCall {
+	return _c.Parent.OnV2Carrot()
+}
+
+func (_c *cherryV2CarrotCall) OnV2CarrotRaw() *cherryV2CarrotCall {
+	return _c.Parent.OnV2CarrotRaw()
 }

--- a/testdata/src/a/mock_test.go
+++ b/testdata/src/a/mock_test.go
@@ -11,6 +11,7 @@ import (
 // mocktail:b.Carrot
 // mocktail-:fmt.Stringer
 // mocktail:Orange
+// mocktail:d.Cherry
 
 func TestName(t *testing.T) {
 	var s Pineapple = newPineappleMock(t).


### PR DESCRIPTION
This PR fixes versionned package.

 ```go
package demo

import "github.com/dep/v1"

type Demo interface {
   Get() dep.Toto
}
```

Before the PR this code was generated:

```go
import "github.com/dep/v1"

func Get() v1.Toto {
}
```

After the PR:

```go
import "github.com/dep/v1"

func Get() dep.Toto {
}
```